### PR TITLE
feat(infra): switch publishing from GitHub Package Registry to npm

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: GPR Publish 
+name: Publish
 on: [ push ]
 jobs:
   build:
@@ -14,20 +14,20 @@ jobs:
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
-      - 
-        run: npm install -g yarn 
+      -
+        run: npm install -g yarn
       -
         run: yarn install --frozen-lockfile
-      - 
+      -
         run: yarn run build
-      - 
-        run: yarn run semantic-release -- --dry-run
+      -
+        run: yarn run semantic-release --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
-      - 
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      -
         run: yarn run semantic-release
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@formidablelabs/dogs",
+  "name": "@formidable/dogs",
   "version": "1.0.0",
   "description": "Formidable Dogs",
   "author": "@FormidableLabs",
@@ -7,11 +7,8 @@
   "repository": {
     "url": "git+https://github.com/FormidableLabs/dogs.git"
   },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
-    "build": "rimraf dist/ && tsc"
+    "build": "rimraf dist && tsc"
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Notes
I've published [`@formidable/dogs@1.0.0`](https://www.npmjs.com/package/@formidable/dogs) to npm manually and set up `dogs-ci` npm user with very limited permission to _just_ publish to this package. All info for `dogs-ci` is in 1password IC vault.

## Work
- Rename package to `@formidable/dogs` to match our npm org.
- Add `NPM_TOKEN` secret to GH secrets in this repo for an automation scoped publish right for the `dogs-ci` user.
- Rename `gpr-publish` to `publish` to be more generic and switch to hopefully npm publishing.
- Choose `feat` for commit to trigger a new full build and hopefully publish to npm.

@iandvt -- Can you look this over and make sure it looks like I got everything correct? Feel free to directly add commits and merge this PR if you think we're in good shape.