### PR TITLE
bug(npm): add cwd npmrc for ci/cd release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,8 @@ jobs:
       -
         run: yarn run build
       -
+        run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+      -
         run: yarn run semantic-release --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 node_modules/
 dist/
 .npmrc
+yarn-error.log


### PR DESCRIPTION
## Work 
- Add local working directory `.npmrc` to force use of `NPM_TOKEN` for authentication parts of `semantic-release`
- Ignore yarn-error.log

## Tasks
- [x] Remove debugging stuff.