### PR TITLE
fix: new release with luna

### DIFF
--- a/semantic.yml
+++ b/semantic.yml
@@ -1,0 +1,4 @@
+# semantic-pull-request configuration
+
+# We _only_ care about PR title because we only do squash and merge.
+titleOnly: true


### PR DESCRIPTION
We didn't actually release `dogs` when @mattjw79 added Luna because of the issues discussed in #28 and #21 . This PR is just an empty commit so we can dogfood our new `semantic-pull-request` workflow from #29 and test that we actually release on merge.