### PR TITLE
refactor!: update typescript and convert to ESM package: Major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ $ npm install @formidable/dogs
 $ yarn add @formidable/dogs
 ```
 
+## Use
+
+```
+import dogs from '@formidable/dogs';
+
+// You can also import the Dog type if needed
+import dogs, { Dog } from '@formidable/dogs';
+```
+
 ## Contributing
 
 This repository is configured using [semantic-release](https://github.com/semantic-release/semantic-release) which automates the whole package release workflow including: determining the next version number, generating the release notes and publishing the package.

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     "build": "rimraf dist && tsc"
   },
   "main": "dist/index.js",
+  "type": "module",
   "typings": "dist/index.d.ts",
   "dependencies": {},
   "devDependencies": {
     "@semantic-release/git": "^9.0.0",
     "rimraf": "^3.0.2",
     "semantic-release": "^17.2.4",
-    "typescript": "^4.0.3"
+    "typescript": "^5.2.2"
   },
   "release": {
     "branches": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,295 +1,356 @@
-type Dogs = {
+export type Dog = {
   key: string;
   name: string;
   breed: string;
   color: string;
   imageUrl: string;
   description: string;
-}
+};
 
-const dogs: Dogs[] = [
+const dogs: Dog[] = [
   {
-    "key": "r17cRT2uW",
-    "name": "Milo",
-    "breed": "Chihuahua",
-    "color": "Tan",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/milo.jpg",
-    "description": "This sassy little dog has a super-size personality. He knows what he wants and goes after it with single-minded determination. For his size, he’s an excellent watchdog, but he can be yappy if he’s not taught to moderate his barking."
+    key: 'r17cRT2uW',
+    name: 'Milo',
+    breed: 'Chihuahua',
+    color: 'Tan',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/milo.jpg',
+    description:
+      'This sassy little dog has a super-size personality. He knows what he wants and goes after it with single-minded determination. For his size, he’s an excellent watchdog, but he can be yappy if he’s not taught to moderate his barking.',
   },
   {
-    "key": "H1jyJC2_b",
-    "name": "Beau",
-    "breed": "Labrador Retriever",
-    "color": "Chocolate",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/beau.jpg",
-    "description": "The Labrador Retriever was bred to be both a friendly companion and a useful working dog breed. Historically, he earned his keep as a fisherman’s helper: hauling nets, fetching ropes, and retrieving fish from the chilly North Atlantic."
+    key: 'H1jyJC2_b',
+    name: 'Beau',
+    breed: 'Labrador Retriever',
+    color: 'Chocolate',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/beau.jpg',
+    description:
+      'The Labrador Retriever was bred to be both a friendly companion and a useful working dog breed. Historically, he earned his keep as a fisherman’s helper: hauling nets, fetching ropes, and retrieving fish from the chilly North Atlantic.',
   },
   {
-    "key": "VmeRTX7j-",
-    "name": "Dixie",
-    "breed": "Pit Mix",
-    "color": "Brown",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/dixie.jpg",
-    "description": "Pit Bull dogs have historically been known as courageous and heroic animals. Pit Bulls are naturally friendly, active dogs that need a lot of exercise. Most Pits are patient and adore children, which makes them wonderful family dogs."
+    key: 'VmeRTX7j-',
+    name: 'Dixie',
+    breed: 'Pit Mix',
+    color: 'Brown',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/dixie.jpg',
+    description:
+      'Pit Bull dogs have historically been known as courageous and heroic animals. Pit Bulls are naturally friendly, active dogs that need a lot of exercise. Most Pits are patient and adore children, which makes them wonderful family dogs.',
   },
   {
-    "key": "rJKI1Rhu-",
-    "name": "Leo",
-    "breed": "Goldendoodle",
-    "color": "Tan",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/leo.jpg",
-    "description": "Goldendoodle is a hybrid of a Golden Retriever and a Standard Poodle. While Labradoodles were bred to be guide dogs for vision-impaired people with dog-sensitive allergies, Goldendoodles have been bred primarily to be family pets, although they can also make terrific service dogs."
+    key: 'rJKI1Rhu-',
+    name: 'Leo',
+    breed: 'Goldendoodle',
+    color: 'Tan',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/leo.jpg',
+    description:
+      'Goldendoodle is a hybrid of a Golden Retriever and a Standard Poodle. While Labradoodles were bred to be guide dogs for vision-impaired people with dog-sensitive allergies, Goldendoodles have been bred primarily to be family pets, although they can also make terrific service dogs.',
   },
   {
-    "key": "tEQM4Lzj_",
-    "name": "Sophie",
-    "breed": "Mutt with Border Collie DNA",
-    "color": "Black",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/sophie.jpg",
-    "description": "Sophie does tricks, enthusiastic barker, fan of the boss’s organic salmon, diagnosed OCD."
+    key: 'tEQM4Lzj_',
+    name: 'Sophie',
+    breed: 'Mutt with Border Collie DNA',
+    color: 'Black',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/sophie.jpg',
+    description:
+      'Sophie does tricks, enthusiastic barker, fan of the boss’s organic salmon, diagnosed OCD.',
   },
   {
-    "key": "cLnG8C2d_",
-    "name": "Rusty",
-    "breed": "Chihuahua",
-    "color": "Brown",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/rusty.jpg",
-    "description": "Fourteen pounds of speedy, food-seeking, barkiness."
+    key: 'cLnG8C2d_',
+    name: 'Rusty',
+    breed: 'Chihuahua',
+    color: 'Brown',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/rusty.jpg',
+    description: 'Fourteen pounds of speedy, food-seeking, barkiness.',
   },
   {
-    "key": "Sk1GkChuZ",
-    "name": "Lucy",
-    "breed": "Beagle",
-    "color": "White and Brown",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/lucy.jpg",
-    "description": "Beagles are scenthounds, meaning they live to use their nose. They’re a comfortable size to tote around in your car, simple to groom, and their exercise needs are easily met with a long, meandering walk that gives them plenty of time to sniff."
+    key: 'Sk1GkChuZ',
+    name: 'Lucy',
+    breed: 'Beagle',
+    color: 'White and Brown',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/lucy.jpg',
+    description:
+      'Beagles are scenthounds, meaning they live to use their nose. They’re a comfortable size to tote around in your car, simple to groom, and their exercise needs are easily met with a long, meandering walk that gives them plenty of time to sniff.',
   },
   {
-    "key": "HJMVJR3ub",
-    "name": "Callie",
-    "breed": "West Highland White Terrier",
-    "color": "White",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/callie.jpg",
-    "description": "You may recognize the Westie from her long-running stint as the mascot for Cesar pet food, but she’s more than just a cute face. A true terrier, she’s a fast and clever hunter, plus her lighthearted nature makes for a pet who’s always game for some fun."
+    key: 'HJMVJR3ub',
+    name: 'Callie',
+    breed: 'West Highland White Terrier',
+    color: 'White',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/callie.jpg',
+    description:
+      'You may recognize the Westie from her long-running stint as the mascot for Cesar pet food, but she’s more than just a cute face. A true terrier, she’s a fast and clever hunter, plus her lighthearted nature makes for a pet who’s always game for some fun.',
   },
   {
-    "key": "BknG9C2d-",
-    "name": "Boba",
-    "breed": "Pomeranian",
-    "color": "Brown",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/boba.jpg",
-    "description": "Tiny and bright-eyed, the spunky Pomeranian greets the world with endless curiosity and a sure sense that he’s the cutest thing around. He is clever, adaptable, and happy, whether hanging at home or performing as a top athlete on an agility course."
+    key: 'BknG9C2d-',
+    name: 'Boba',
+    breed: 'Pomeranian',
+    color: 'Brown',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/boba.jpg',
+    description:
+      'Tiny and bright-eyed, the spunky Pomeranian greets the world with endless curiosity and a sure sense that he’s the cutest thing around. He is clever, adaptable, and happy, whether hanging at home or performing as a top athlete on an agility course.',
   },
   {
-    "key": "Bkn7Hq9d-",
-    "name": "Cleo",
-    "breed": "Terrier-Schnauzer Mix",
-    "color": "Salt & Pepper",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/cleo.jpg",
-    "description": "Advancing the collected intelligence of the canine species, Cleo is smart, compassionate, and v good at snuggling. Hobbies include curling up like a donut, barking at mail-carriers, and frequent zoomies."
+    key: 'Bkn7Hq9d-',
+    name: 'Cleo',
+    breed: 'Terrier-Schnauzer Mix',
+    color: 'Salt & Pepper',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/cleo.jpg',
+    description:
+      'Advancing the collected intelligence of the canine species, Cleo is smart, compassionate, and v good at snuggling. Hobbies include curling up like a donut, barking at mail-carriers, and frequent zoomies.',
   },
   {
-    "key": "uTW2q9d_",
-    "name": "Levi",
-    "breed": "Golden Retriever",
-    "color": "Yellow",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/levi.jpg",
-    "description": "Levi, aka 'Air Spud' is a very large adult boy who is fascinated by tennis balls & jerky treats. His personality often resembles that of a potato, though he is a very happy & big-hearted creature. Currently pursuing swimming & whatever the humans left out on the kitchen counter."
+    key: 'uTW2q9d_',
+    name: 'Levi',
+    breed: 'Golden Retriever',
+    color: 'Yellow',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/levi.jpg',
+    description:
+      "Levi, aka 'Air Spud' is a very large adult boy who is fascinated by tennis balls & jerky treats. His personality often resembles that of a potato, though he is a very happy & big-hearted creature. Currently pursuing swimming & whatever the humans left out on the kitchen counter.",
   },
   {
-    "key": "1HHChuZd8",
-    "name": "Harley",
-    "breed": "Mutt",
-    "color": "Black",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/harley.jpg",
-    "description": "Land seal. Tries hard af."
+    key: '1HHChuZd8',
+    name: 'Harley',
+    breed: 'Mutt',
+    color: 'Black',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/harley.jpg',
+    description: 'Land seal. Tries hard af.',
   },
   {
-    "key": "rWD2q1s_",
-    "name": "Laughlan",
-    "breed": "Labrador Retriever",
-    "color": "Chocolate",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/laughlan1.jpg",
-    "description": "Loves swimming and long walks. Snores like a human."
+    key: 'rWD2q1s_',
+    name: 'Laughlan',
+    breed: 'Labrador Retriever',
+    color: 'Chocolate',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/laughlan1.jpg',
+    description: 'Loves swimming and long walks. Snores like a human.',
   },
   {
-    "key": "bQo_598qR",
-    "name": "Otis",
-    "breed": "Husky Dane mix",
-    "color": "Black",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/otis.jpg",
-    "description": "Found on Lookout Mountain in Colorado, Otis is an energetic, noisy mutt that will always choose to dive into cacti in pursuit of lizards. He is currently interested in anything that moves or makes a strange sound."
+    key: 'bQo_598qR',
+    name: 'Otis',
+    breed: 'Husky Dane mix',
+    color: 'Black',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/otis.jpg',
+    description:
+      'Found on Lookout Mountain in Colorado, Otis is an energetic, noisy mutt that will always choose to dive into cacti in pursuit of lizards. He is currently interested in anything that moves or makes a strange sound.',
   },
   {
-    "key": "sQm_623qM",
-    "name": "Boone",
-    "breed": "Labrador Retriever",
-    "color": "Black",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/boone.jpg",
-    "description": "A larger, fluffier, darker colored version of Laughlan. Very good at cuddling"
+    key: 'sQm_623qM',
+    name: 'Boone',
+    breed: 'Labrador Retriever',
+    color: 'Black',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/boone.jpg',
+    description:
+      'A larger, fluffier, darker colored version of Laughlan. Very good at cuddling',
   },
   {
-    "key": "jar_6493st",
-    "name": "Zeus",
-    "breed": "Lab Dane Mix",
-    "color": "Yellow",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/zeus.jpg",
-    "description": "He is big. He is loveable. He is goofy. Most of all--he is Zeus."
+    key: 'jar_6493st',
+    name: 'Zeus',
+    breed: 'Lab Dane Mix',
+    color: 'Yellow',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/zeus.jpg',
+    description:
+      'He is big. He is loveable. He is goofy. Most of all--he is Zeus.',
   },
   {
-    "key": "3TAkEh&n",
-    "name": "Daisy",
-    "breed": "Boston Terrier",
-    "color": "Black & White",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/daisy.jpg",
-    "description": "Aggresive kisser and spoiled lap dog."
+    key: '3TAkEh&n',
+    name: 'Daisy',
+    breed: 'Boston Terrier',
+    color: 'Black & White',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/daisy.jpg',
+    description: 'Aggresive kisser and spoiled lap dog.',
   },
   {
-    "key": "S_eu6vPq",
-    "name": "Penelope",
-    "breed": "French Bulldog mix",
-    "color": "Black & White",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/penelope.jpg",
-    "description": "Snorts like a pig, but sophisticated like a peacock."
+    key: 'S_eu6vPq',
+    name: 'Penelope',
+    breed: 'French Bulldog mix',
+    color: 'Black & White',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/penelope.jpg',
+    description: 'Snorts like a pig, but sophisticated like a peacock.',
   },
   {
-    "key": "jar_6492ux",
-    "name": "Cassie",
-    "breed": "Beagle",
-    "color": "Tri-color",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/cassie.jpg",
-    "description": "Cassie has crossed the rainbow bridge.  She was loyal, fat, and always hungry, like her owner."
+    key: 'jar_6492ux',
+    name: 'Cassie',
+    breed: 'Beagle',
+    color: 'Tri-color',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/cassie.jpg',
+    description:
+      'Cassie has crossed the rainbow bridge.  She was loyal, fat, and always hungry, like her owner.',
   },
   {
-    "key": "jar_8re3qux",
-    "name": "Ellie Mae",
-    "breed": "Beagle",
-    "color": "Tri-color",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/elliemae.jpg",
-    "description": "Loves to play and sleep.  Still a puppy after 14 years."
+    key: 'jar_8re3qux',
+    name: 'Ellie Mae',
+    breed: 'Beagle',
+    color: 'Tri-color',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/elliemae.jpg',
+    description: 'Loves to play and sleep.  Still a puppy after 14 years.',
   },
   {
-    "key": "bar_9uie1278",
-    "name": "Annie",
-    "breed": "Beagle",
-    "color": "Tri-color",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/annie.jpg",
-    "description": "Mischevious food and dirty diaper bandit.  Survivor of anal-gland carcinoma (srsly)."
+    key: 'bar_9uie1278',
+    name: 'Annie',
+    breed: 'Beagle',
+    color: 'Tri-color',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/annie.jpg',
+    description:
+      'Mischevious food and dirty diaper bandit.  Survivor of anal-gland carcinoma (srsly).',
   },
   {
-    "key": "ngk_4kmk6",
-    "name": "Odie",
-    "breed": "Lab/Husky/Springer Spaniel/Cocker Spaniel Mix",
-    "color": "Yellow",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/odie.jpg",
-    "description": "As lovable as he is strange! Inseparable from his brother Charlie and his people! Chases shadows and stares at corners for hours! Fiercely loyal and master snuggle haver! Allergic to everything! Confused by his own farts!"
+    key: 'ngk_4kmk6',
+    name: 'Odie',
+    breed: 'Lab/Husky/Springer Spaniel/Cocker Spaniel Mix',
+    color: 'Yellow',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/odie.jpg',
+    description:
+      'As lovable as he is strange! Inseparable from his brother Charlie and his people! Chases shadows and stares at corners for hours! Fiercely loyal and master snuggle haver! Allergic to everything! Confused by his own farts!',
   },
   {
-    "key": "l5hf_j34j",
-    "name": "Charlie",
-    "breed": "Half Rat Terrier, Half Mutt",
-    "color": "Yellow",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/charlie.jpg",
-    "description": "An unstoppable bundle of joy and friendship! Loves his friends in the Seattle office. Tolerates his brother's incessant ear chewing. Wags could power a wind turbine. The happiest little skunk you'll ever meet!"
+    key: 'l5hf_j34j',
+    name: 'Charlie',
+    breed: 'Half Rat Terrier, Half Mutt',
+    color: 'Yellow',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/charlie.jpg',
+    description:
+      "An unstoppable bundle of joy and friendship! Loves his friends in the Seattle office. Tolerates his brother's incessant ear chewing. Wags could power a wind turbine. The happiest little skunk you'll ever meet!",
   },
   {
-    "key": "bnf_13kj",
-    "name": "Fred 'Baby' Diamond",
-    "breed": "Cotralian",
-    "color": "Red",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/fred.jpg",
-    "description": "Half Mini Australian Shepard, half Cocker Spaniel. Enjoys ball, sunshine naps, and stealing his owners' socks. Living the good life in Phoenix, Arizona."
+    key: 'bnf_13kj',
+    name: "Fred 'Baby' Diamond",
+    breed: 'Cotralian',
+    color: 'Red',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/fred.jpg',
+    description:
+      "Half Mini Australian Shepard, half Cocker Spaniel. Enjoys ball, sunshine naps, and stealing his owners' socks. Living the good life in Phoenix, Arizona.",
   },
   {
-    "key": "kr_32619",
-    "name": "Baker",
-    "breed": "Braque Francais Pyrenees",
-    "color": "White",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/baker.jpg",
-    "description": "Born January 23, 2019, our sweet and friendly 9 week old puppy will grow into a  medium-sized dog with a soft, shorthaired coat with a gentle and family friendly character. He was bred to hunt the very rugged and arid Pyrenees Mountain range on the border of France and Spain. We look forward to many years of outdoor adventures with our new best friend."
+    key: 'kr_32619',
+    name: 'Baker',
+    breed: 'Braque Francais Pyrenees',
+    color: 'White',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/baker.jpg',
+    description:
+      'Born January 23, 2019, our sweet and friendly 9 week old puppy will grow into a  medium-sized dog with a soft, shorthaired coat with a gentle and family friendly character. He was bred to hunt the very rugged and arid Pyrenees Mountain range on the border of France and Spain. We look forward to many years of outdoor adventures with our new best friend.',
   },
   {
-    "key": "lcn3_t8h1",
-    "name": "Milo",
-    "breed": "Yorkie",
-    "color": "Tan",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/milo_cesar.jpg",
-    "description": "This sweet little boy is extremely loving and loves to get belly rubs. He's super quiet and ninja like unless he's meeting another dog for the first time. Loves to hoard toys and hide them."
+    key: 'lcn3_t8h1',
+    name: 'Milo',
+    breed: 'Yorkie',
+    color: 'Tan',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/milo_cesar.jpg',
+    description:
+      "This sweet little boy is extremely loving and loves to get belly rubs. He's super quiet and ninja like unless he's meeting another dog for the first time. Loves to hoard toys and hide them.",
   },
   {
-    "key": "ujm_n5g8aL",
-    "name": "Madden",
-    "breed": "Yorkie mixed",
-    "color": "Black",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/madden.jpg",
-    "description": "He's very sweet and overprotective of his humans but friendly once he knows you. He can only eat certain foods but loves his treats, swimming, and chewing on toys. He gets around extremely well on three legs."
+    key: 'ujm_n5g8aL',
+    name: 'Madden',
+    breed: 'Yorkie mixed',
+    color: 'Black',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/madden.jpg',
+    description:
+      "He's very sweet and overprotective of his humans but friendly once he knows you. He can only eat certain foods but loves his treats, swimming, and chewing on toys. He gets around extremely well on three legs.",
   },
   {
-    "key": "ldg83_o8n4",
-    "name": "Winnie",
-    "breed": "Golden Retriever",
-    "color": "Yellow",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/winnie.jpg",
-    "description": "Winnie is a rambunctious, energetic, and loving golden retriever.  Her favorite past times are playing fetch (her absolute favorite activity), napping, or swimming in the Chesapeake Bay."
+    key: 'ldg83_o8n4',
+    name: 'Winnie',
+    breed: 'Golden Retriever',
+    color: 'Yellow',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/winnie.jpg',
+    description:
+      'Winnie is a rambunctious, energetic, and loving golden retriever.  Her favorite past times are playing fetch (her absolute favorite activity), napping, or swimming in the Chesapeake Bay.',
   },
   {
-    "key": "isl15_ks84",
-    "name": "Islay",
-    "breed": "Black Mouth Cur",
-    "color": "Brown and Black",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/islay.jpg",
-    "description": "Islay is named for a beautiful island in Scotland, her name is pronounced Eye-lah. She is a very high energy girl who loves to hunt squirrels, rabbits, and mice. On occasion she even catches one. She is obsessed with any and all food and may have already swiped your lunch off of your desk."
+    key: 'isl15_ks84',
+    name: 'Islay',
+    breed: 'Black Mouth Cur',
+    color: 'Brown and Black',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/islay.jpg',
+    description:
+      'Islay is named for a beautiful island in Scotland, her name is pronounced Eye-lah. She is a very high energy girl who loves to hunt squirrels, rabbits, and mice. On occasion she even catches one. She is obsessed with any and all food and may have already swiped your lunch off of your desk.',
   },
   {
-    "key": "jun0_5hbgm",
-    "name": "Juno",
-    "breed": "Toxirn",
-    "color": "Brown",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/juno.jpg",
-    "description": "Juno is a spunky little lady who loves her toys and cuddles on the couch."
+    key: 'jun0_5hbgm',
+    name: 'Juno',
+    breed: 'Toxirn',
+    color: 'Brown',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/juno.jpg',
+    description:
+      'Juno is a spunky little lady who loves her toys and cuddles on the couch.',
   },
   {
-    "key": "r3yn_5scmm",
-    "name": "Reyn",
-    "breed": "Miniature Australian Shepherd",
-    "color": "Black, Brown, and White",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/reyn.jpg",
-    "description": "Reyn is a sweet and shy girl who loves her treats and walks with her sister."
+    key: 'r3yn_5scmm',
+    name: 'Reyn',
+    breed: 'Miniature Australian Shepherd',
+    color: 'Black, Brown, and White',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/reyn.jpg',
+    description:
+      'Reyn is a sweet and shy girl who loves her treats and walks with her sister.',
   },
   {
-    "key": "sc0ut_0mxld",
-    "name": "Scout",
-    "breed": "Schnauzer Mix",
-    "color": "Black and White",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/scout.jpg",
-    "description": "Scout is a wild rescue who barks at any kind of large vehicle she sees. She enjoys a greenie treat every morning and knows about 8 tricks so far."
+    key: 'sc0ut_0mxld',
+    name: 'Scout',
+    breed: 'Schnauzer Mix',
+    color: 'Black and White',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/scout.jpg',
+    description:
+      'Scout is a wild rescue who barks at any kind of large vehicle she sees. She enjoys a greenie treat every morning and knows about 8 tricks so far.',
   },
   {
-    "key": "ril3y_85MhC",
-    "name": "Riley",
-    "breed": "Goldendoodle",
-    "color": "Apricot",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/riley.jpg",
-    "description": "A middle aged meerkat disguised as a Gooldendoodle."
+    key: 'ril3y_85MhC',
+    name: 'Riley',
+    breed: 'Goldendoodle',
+    color: 'Apricot',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/riley.jpg',
+    description: 'A middle aged meerkat disguised as a Gooldendoodle.',
   },
   {
-    "key": "lun4_3s935",
-    "name": "Luna",
-    "breed": "Chihuahua Mix",
-    "color": "Black and White",
-    "imageUrl": "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/luna.jpg",
-    "description": "Luna is a momma's girl that occasionally cuddles with the cat, or even dad if necessary. She also loves eating dried up worms on her walks."
+    key: 'lun4_3s935',
+    name: 'Luna',
+    breed: 'Chihuahua Mix',
+    color: 'Black and White',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/luna.jpg',
+    description:
+      "Luna is a momma's girl that occasionally cuddles with the cat, or even dad if necessary. She also loves eating dried up worms on her walks.",
   },
   {
-    "key": "n3v3_jg73a",
-    "name": "Neve",
-    "breed": "Standard Schnauzer",
-    "color": "Salt & Pepper",
-    "imageUrl":
-      "https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/neve.jpg",
-    "description":
-      "A softee at heart, but very anxious around other people and anything that makes unexpected sounds!",
-  }
-]
+    key: 'n3v3_jg73a',
+    name: 'Neve',
+    breed: 'Standard Schnauzer',
+    color: 'Salt & Pepper',
+    imageUrl:
+      'https://raw.githubusercontent.com/FormidableLabs/dogs/main/src/neve.jpg',
+    description:
+      'A softee at heart, but very anxious around other people and anything that makes unexpected sounds!',
+  },
+];
 
 export default dogs;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ES6",
+    "module": "ES2022",
     "moduleResolution": "node",
     "declaration": true,
     "removeComments": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4344,10 +4344,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 uglify-js@^3.1.4:
   version "3.11.2"


### PR DESCRIPTION
- Bringing this package to more modern times by converting it to an ES module and updating typescript.
- You can export the `dogs` data as default and the `Dog` type as a name export if needed.

ex. `import dogs, { Dog } from '@formidable/dogs';`